### PR TITLE
documentation: change 'fcqrO9HWcINS2Qq' to 'uOyjAtdvYjxxwZd' in the urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ If this is the **first time** that you download SSIMP, create a folder typing th
 ```
 cd ~
 mkdir reference_panels
-wget https://drive.switch.ch/index.php/s/fcqrO9HWcINS2Qq/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
+wget https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
 ```
  
 If you had previous versions of SSIMP installed, you **NEED to redownload** the database. 
 ```
-wget https://drive.switch.ch/index.php/s/fcqrO9HWcINS2Qq/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
+wget https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
 ```
 
 ## Installation
@@ -191,7 +191,7 @@ Report bugs here: (https://github.com/sinarueeger/ssimp_software/issues)[https:/
 If you are having trouble with SSIMP versions >= 0.4, make sure that you delete your database in folder `~/reference_panels/database*` and redownload it using the following command
 
 ```
-wget https://drive.switch.ch/index.php/s/fcqrO9HWcINS2Qq/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
+wget https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
 ```
 
 <!--## Wiki / FAQ

--- a/docu/usage.txt
+++ b/docu/usage.txt
@@ -92,7 +92,7 @@ if it is available on your machine:
 
 Additionally, download the dataset that allows you fast imputation of single SNPs.
 
-wget https://drive.switch.ch/index.php/s/fcqrO9HWcINS2Qq/download -O database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
+wget https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download -O database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
 
 You can then pass this directory name to 'ssimp', and specify that only
 the European individuals should be used:


### PR DESCRIPTION
Some of the database urls in the documentation are incorrect. This PR changes the documentation to use the correct URL.

We should recompile the binaries also. The good news is that the binaries already download the correct one if you allow it to do so. But the usage message in incorrect, and therefore we need to recompile in order to get the correct usage message into the binary