### PR TITLE
Add a short 'Troubleshooting' section, relevant for the recent bug reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ If you had previous versions of SSIMP installed, you **NEED to redownload** the 
 wget https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download -O ~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin
 ```
 
+## Troubleshooting
+
+You may get assertion errors when running this, even after following the *Installation* Instructions. Please also check the *Bug Reports* section below. Here are a couple of things you can check:
+1) the size of the build database should be `1'789'839'360` bytes: `~/reference_panels/database.of.builds.1kg.uk10k.hrc.2018.01.18.bin`. If not, see *Bug Reports* below on how to download an updated version
+2) The simplest way to call this is with: `ssimp gwas/small.random.txt 1KG/EUR output.txt`. Otherwise, you can select the AFR population with: `ssimp gwas/small.random.txt ~/reference_panels/1000genomes/ALL.chr{CHRM}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz output.txt --sample.names ~/reference_panels/1000genomes/integrated_call_samples_v3.20130502.ALL.panel/sample/super_pop=AFR`. In either case, if you wish to impute only a particular chromosome, you can use `--impute.range chr17`. Do *not* replace the `ALL.chr{CHRM}` with `ALL.chr17`. The only way to restrict to one chromosome is via `--impute.range ...`.
+
+
 ## Installation
 [//]: -------------------------------
 

--- a/ssimp_chunks.sh
+++ b/ssimp_chunks.sh
@@ -78,7 +78,7 @@ library(dplyr) ## for filter
 
 ## download reference file that contains chr/pos
 ## ----------------------------------------------
-url <-"https://drive.switch.ch/index.php/s/e3MuOYEudU1JbUo/download"
+url <-"https://drive.switch.ch/index.php/s/uOyjAtdvYjxxwZd/download"
 file <- "reference_panels/dbsnp_hg20_chr_pos_sorted.txt.gz"
 if(!file.exists(file))
 {


### PR DESCRIPTION
A common issue is the version of the the database, which you can check by its size

Also, the `chr{CHRM}` is important on the path to the reference panel (if you're using 1KG/EUR).