### PR TITLE
Delete SNPs where the two allele names are identical. 

### DIFF
--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -353,15 +353,14 @@ struct SimpleGwasFile : public file_reading:: Effects_I
         );
     }
     virtual int         delete_snps_with_identical_alleles() {
-        int count_those_removed = 0;
-        for(int i=0; i<utils::ssize(m_each_SNP_and_its_z);) {
-            if(this->get_allele_ref(i) == this->get_allele_alt(i)) {
-                ++count_those_removed;
-                m_each_SNP_and_its_z.erase(m_each_SNP_and_its_z.begin() + i);
-            }
-            else
-                ++i;
-        }
+        auto delete_after_me = std::remove_if(
+                            m_each_SNP_and_its_z.begin(),
+                            m_each_SNP_and_its_z.end(),
+                            [](auto const & x) {
+                                return x.m_allele_alt == x.m_allele_ref;
+                            });
+        int count_those_removed = m_each_SNP_and_its_z.end() - delete_after_me;
+        m_each_SNP_and_its_z.erase(delete_after_me, m_each_SNP_and_its_z.end());
         return count_those_removed;
     }
 

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -352,6 +352,18 @@ struct SimpleGwasFile : public file_reading:: Effects_I
                 ++i;
         }
     }
+    virtual int         delete_snps_with_identical_alleles() {
+        int count_those_removed = 0;
+        for(int i=0; i<utils::ssize(m_each_SNP_and_its_z);) {
+            if(this->get_allele_ref(i) == this->get_allele_alt(i)) {
+                ++count_those_removed;
+                m_each_SNP_and_its_z.erase(m_each_SNP_and_its_z.begin() + i);
+            }
+            else
+                ++i;
+        }
+        return count_those_removed;
+    }
 
     GwasLineSummary  get_gls         (int i)     const {
         assert(i>=0);

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -343,14 +343,14 @@ struct SimpleGwasFile : public file_reading:: Effects_I
             );
     }
     virtual void        delete_snps_with_no_position() {
-        for(int i=0; i<utils::ssize(m_each_SNP_and_its_z);) {
-            if(this->get_chrpos(i) == chrpos{-1,-1}) {
-                assert( (m_each_SNP_and_its_z.begin()+i)->m_chrpos == chrpos({-1,-1}) );
-                m_each_SNP_and_its_z.erase(m_each_SNP_and_its_z.begin() + i);
-            }
-            else
-                ++i;
-        }
+        m_each_SNP_and_its_z.erase(
+            std::remove_if( m_each_SNP_and_its_z.begin(),
+                            m_each_SNP_and_its_z.end(),
+                            [](auto const & x) {
+                                return x.m_chrpos == chrpos{-1,-1};
+                            }),
+            m_each_SNP_and_its_z.end()
+        );
     }
     virtual int         delete_snps_with_identical_alleles() {
         int count_those_removed = 0;

--- a/src/file.reading.hh
+++ b/src/file.reading.hh
@@ -87,6 +87,7 @@ struct Effects_I : public AnyFile_I {
     virtual void        set_chrpos         (int, chrpos)  = 0; // so that we can fill them in from the ref data
     virtual void        sort_my_entries    ()             = 0;
     virtual void        delete_snps_with_no_position()    = 0;
+    virtual int         delete_snps_with_identical_alleles()    = 0;
     virtual double      get_z              (int) const    = 0;
     virtual double      get_N              (int) const    = 0;
     virtual std::string get_column_name_allele_ref () const       = 0;

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -718,6 +718,12 @@ int main(int argc, char **argv) {
 
     if(!options:: opt_raw_ref.empty() && !options:: opt_gwas_filename.empty()) {
         auto gwas         = file_reading:: read_in_a_gwas_file(options:: opt_gwas_filename);
+        {
+            auto count_those_removed = gwas->delete_snps_with_identical_alleles();
+            if(count_those_removed > 0) {
+                cout << "Deleted " << count_those_removed << " SNPs as the two allele names are identical.\n";
+            }
+        }
 
         auto database_of_builds = ssimp:: load_database_of_builds();
         std:: map<int, size_t> database_of_builds_rs_to_offset;


### PR DESCRIPTION
This can happen where both are 'na', for example.