### PR TITLE
Recompile.for.text.change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This command-line software enables summary statistics imputation (SSimp) for GWA
 The only input needed from the user are the **GWAS summary statistics** and a **reference panel** (e.g. 1000 genomes, needed for LD computation).
 
 
-## Current version: 0.5.1
+## Current version: 0.5.2
 [//]: -------------------------------
 
 **Important**: along with the SSIMP installation, you will also need to download a file (a database with all positions on different builds) into your `~/reference_panel/` folder. 

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,8 @@
 Versions of SSIMP
 
+ssimp-0.5.2     (2018-11-02)
+                - various documentation updates
+
 ssimp-0.5.1     (2018-10-29)
                 - offer to download the 1000genomes if it is requested via --ref
 

--- a/compiled/howto.txt
+++ b/compiled/howto.txt
@@ -1,10 +1,19 @@
-If stu is not installed, use the version in this repository that can be called via stu/stu.
+If stu is not installed, use the version in this repository. It can be built here with 'make stu/stu',
+and then you can use 'stu/stu' instead of 'stu' in the rest of this document
+
+## Version number update?
+Before building the binaries, you probably want to update the version numbers. Currently, this means:
+ - edit the first line of [doc/usage.txt]
+ - edit the 'current version' entry in [README.md]
+ - add a new entry to the top of [VERSION], regarding the changes introduced
+The [doc/usage.txt] should be updated before compilation, as it will be included in the binary
 
 ## on LINUX (e.g. HPC1)
 
 stu bin/ssimp-static   # to build the statically-linked version of the executable
 cp bin/ssimp-static compiled/ssimp-linux-VERSION
 git add compiled/ssimp-linux-VERSION
+git rm  compiled/ssimp-linux-OLDVERSION
 git commit -m "statically-linked executable for LINUX"
 
 
@@ -20,4 +29,5 @@ The 'crt' library was our problem and it appears that Apple refuse to make a sta
 stu/stu bin/ssimp  # to build the statically-linked version of the executable
 cp bin/ssimp compiled/ssimp-osx-VERSION
 git add compiled/ssimp-osx-VERSION
+git  rm compiled/ssimp-osx-OLDVERSION
 git commit -m "executable for OSX"

--- a/doc/usage.txt
+++ b/doc/usage.txt
@@ -1,4 +1,4 @@
-[ssimp-0.5.1     (2018-10-29)]
+[ssimp-0.5.2     (2018-11-02)]
 
 ssimp   GWASFILE REFPANEL IMPUTATIONOUTPUT  [OPTIONS]
 ssimp   --gwas GWASFILE --ref REFPANEL --out IMPUTATIONOUTPUT


### PR DESCRIPTION
(This needs a new Mac binary too, but I (aaron) can't do that)

A few things:
 - A new linux binary, v0.5.2. I think it's the same as 0.5.1, but with a new usage message
 - Add stuff in `howto.txt` about updating the version number
 - Change version from 0.5.1 to 0.5.2 (required for the new usage message)

[In hindsight, perhaps I shouldn't increase the version number for such a tiny change. We did discuss the idea of making larger pull requests, containing multiple improvements. I'll try that in future!]