### PR TITLE
No.need.for. debug build chr.any.more

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,9 @@
 Versions of SSIMP
 
 (unreleased)    (???)
-                - (debug) faster testing, with a 'hidden' option _debug_build_chr
+                - to save memory and time, load only a subset of the build
+                  database for the relevant chromosomes. This applies if
+                  --impute.range or --tag.range are specified.
 
 ssimp-0.5.2     (2018-11-07)
                 - various documentation updates

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -429,6 +429,8 @@ static
     );
 
 
+static
+std:: pair<chrpos,chrpos> parse_range_as_pair_of_chrpos(string const &as_text);
 } // namespace ssimp
 
 static
@@ -694,6 +696,19 @@ int main(int argc, char **argv) {
     //        is looked up in the 1kg panel file. If any of those
     //        strings appears in any of the columns, then that
     //        sample is used.
+
+    // If --impute.range or --tag.range is specified, then we can optimize
+    // by arranging that only the relevant subset of the build database is loaded
+    for(auto * either_impute_or_tag : { &options::opt_impute_range, &options::opt_tag_range }) {
+        if(!either_impute_or_tag->empty()) {
+            auto range_parsed =  ssimp::parse_range_as_pair_of_chrpos(*either_impute_or_tag);
+            int     a_chromosome = range_parsed.first.chr;
+            int  last_chromosome = range_parsed.second.chr;
+            for(;a_chromosome <= last_chromosome; ++a_chromosome) {
+                options::opt_debug_build_chromosomes_to_load.insert(a_chromosome);
+            }
+        }
+    }
 
     // But first, check if the relevant directory exists and, if it doesn't
     // exist, explain to the user how to download it

--- a/tests/3.chromosomes/UKB.every100/command
+++ b/tests/3.chromosomes/UKB.every100/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                  \
     --lambda 0.01                                                               \
     --tag.range  chr1-chr2                                                         \
-    --_debug_build_chr 1 --_debug_build_chr 2                                       \
     > "$OUTPUT"

--- a/tests/impute.maf/0.05/command
+++ b/tests/impute.maf/0.05/command
@@ -6,5 +6,4 @@
     --lambda 0.01                                                                   \
     --impute.maf    0.05                                                            \
     --tag.range  chr1-chr2                                                         \
-    --_debug_build_chr 1 --_debug_build_chr 2                                       \
     > "$OUTPUT"

--- a/tests/impute.range/chr1_1000000-chr1_2000000/command
+++ b/tests/impute.range/chr1_1000000-chr1_2000000/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.01                                                                   \
     --impute.range  chr1:18040000-chr1:18060000                                     \
-    --_debug_build_chr 1                                                            \
     > "$OUTPUT"

--- a/tests/impute.range/chr2-3/command
+++ b/tests/impute.range/chr2-3/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.01                                                                   \
     --impute.range  chr2-3                                                          \
-    --_debug_build_chr 2 --_debug_build_chr 3                                       \
     > "$OUTPUT"

--- a/tests/impute.range/chr2/command
+++ b/tests/impute.range/chr2/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.01                                                                   \
     --impute.range  chr2                                                            \
-    --_debug_build_chr 2                                                            \
     > "$OUTPUT"

--- a/tests/lambda/0.001/command
+++ b/tests/lambda/0.001/command
@@ -8,7 +8,6 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.001                                                                  \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5 --_debug_build_chr 6                  \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/lambda/0.001/output.actual
+++ b/tests/lambda/0.001/output.actual
@@ -2,13 +2,13 @@ file_name:gwas/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz
 ... loading the 1.7GB database of positions under three builds. This will take about a minute.  Loaded.
 Estimating which build (hg18/hg19/hg37) of the reference panel and the GWAS file, in case it is necessary to modify the GWAS file to match the reference panel
 some_records_from_each_chromosome.size():1'651
-count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 5 , 0 , 0 , 273 , 0
+count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 4 , 0 , 0 , 182 , 0
 gwas_all_chrpos.size():0
 count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 0 , 0 , 0 , 0 , 0
 which_build_gwas,which_build_ref:	unknown , hg19_1
-gwas_count_known,gwas_count_unknown:	170 , 844
+gwas_count_known,gwas_count_unknown:	109 , 905
 Delete the SNPs with unknown position ...
-gwas->number_of_snps():170
+gwas->number_of_snps():109
 options:: opt_window_width,options:: opt_flanking_width:	250'000 , 250'000
 N_reference:503
 

--- a/tests/lambda/0.0891756/command
+++ b/tests/lambda/0.0891756/command
@@ -8,7 +8,6 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.0891756                                                              \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5                                       \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/lambda/0.999/command
+++ b/tests/lambda/0.999/command
@@ -8,7 +8,6 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.999                                                                  \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5                                       \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/lambda/2sqrtn/command
+++ b/tests/lambda/2sqrtn/command
@@ -8,7 +8,6 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda "2/sqrt(n)"                                                            \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5                                       \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/lambda/default/command
+++ b/tests/lambda/default/command
@@ -7,7 +7,6 @@
     --flan 250000                                                                   \
     --out "${OUT_IMPUTATIONS}"                                                      \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5                                       \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/lambda1.0/command
+++ b/tests/lambda1.0/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 1.0                                                                    \
     --impute.range  chr2                                                            \
-    --_debug_build_chr 2                                                            \
     > "$OUTPUT"

--- a/tests/missingness.partchr22/none/command
+++ b/tests/missingness.partchr22/none/command
@@ -10,5 +10,4 @@
     --reimpute.tags                                                                 \
     --missingness none                                                              \
     --impute.range 22:18000000-22:19000000                                          \
-    --_debug_build_chr 22                                                           \
     >     "$OUTPUT"

--- a/tests/missingness1/dep/command
+++ b/tests/missingness1/dep/command
@@ -9,7 +9,7 @@
     --lambda 0.01                                                                   \
     --reimpute.tags                                                                 \
     --missingness dep                                                              \
-    --_debug_build_chr 19                                                           \
+    --impute.range 19                                                               \
     >     "$OUTPUT"
     #--gwas "$GWAS"/too.big/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz \
     #--gwas "$GWAS"/GIANT_HEIGHT_Wood_et_al_justPARTOFCHR19.tsv                      \

--- a/tests/missingness1/ind/command
+++ b/tests/missingness1/ind/command
@@ -9,7 +9,7 @@
     --lambda 0.01                                                                   \
     --reimpute.tags                                                                 \
     --missingness ind                                                              \
-    --_debug_build_chr 19                                                           \
+    --impute.range 19                                                               \
     >     "$OUTPUT"
     #--gwas "$GWAS"/too.big/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz \
     #--gwas "$GWAS"/GIANT_HEIGHT_Wood_et_al_justPARTOFCHR19.tsv                      \

--- a/tests/missingness1/none/command
+++ b/tests/missingness1/none/command
@@ -9,7 +9,7 @@
     --lambda 0.01                                                                   \
     --reimpute.tags                                                                 \
     --missingness none                                                              \
-    --_debug_build_chr 19                                                           \
+    --impute.range 19                                                               \
     >     "$OUTPUT"
     #--gwas "$GWAS"/too.big/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz \
     #--gwas "$GWAS"/GIANT_HEIGHT_Wood_et_al_justPARTOFCHR19.tsv                      \

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..impute.maf/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..impute.maf/command
@@ -8,5 +8,5 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
     --impute.maf  0.001                                                              \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..impute.range/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..impute.range/command
@@ -7,6 +7,5 @@
     --wind 250000                                                                   \
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
-    --impute.range chr1:18016492-CHR22:18482599                                           \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range chr20-CHR22:18482599                                           \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..impute.snps/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..impute.snps/command
@@ -8,5 +8,5 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
     --impute.snps   "${COMMANDDIR}"/_--impute.snps                                  \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.maf/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.maf/command
@@ -8,5 +8,5 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
        --tag.maf  0.01                                                              \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/command
@@ -7,6 +7,5 @@
     --wind 250000                                                                   \
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
-    --tag.range 1:18020299-22:18444733                                              \
-    --impute.range 20-22                                                            \
+    --tag.range 20-22:18444733                                              \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/command
@@ -8,5 +8,5 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
     --tag.range 1:18020299-22:18444733                                              \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/output.actual
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/output.actual
@@ -2,13 +2,13 @@ file_name:gwas/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz
 ... loading the 1.7GB database of positions under three builds. This will take about a minute.  Loaded.
 Estimating which build (hg18/hg19/hg37) of the reference panel and the GWAS file, in case it is necessary to modify the GWAS file to match the reference panel
 some_records_from_each_chromosome.size():1'651
-count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 4 , 0 , 0 , 287 , 0
+count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 30 , 0 , 0 , 1'603 , 0
 gwas_all_chrpos.size():0
 count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 0 , 0 , 0 , 0 , 0
 which_build_gwas,which_build_ref:	unknown , hg19_1
-gwas_count_known,gwas_count_unknown:	160 , 854
+gwas_count_known,gwas_count_unknown:	1'013 , 1
 Delete the SNPs with unknown position ...
-gwas->number_of_snps():160
+gwas->number_of_snps():1'013
 options:: opt_window_width,options:: opt_flanking_width:	250'000 , 250'000
 N_reference:503
 

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/output.actual
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.range/output.actual
@@ -2,13 +2,13 @@ file_name:gwas/GIANT_HEIGHT_Wood_et_al_2014_publicrelease_HapMapCeuFreq.txt.gz
 ... loading the 1.7GB database of positions under three builds. This will take about a minute.  Loaded.
 Estimating which build (hg18/hg19/hg37) of the reference panel and the GWAS file, in case it is necessary to modify the GWAS file to match the reference panel
 some_records_from_each_chromosome.size():1'651
-count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 30 , 0 , 0 , 1'603 , 0
+count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 4 , 0 , 0 , 287 , 0
 gwas_all_chrpos.size():0
 count_of_hg18_0based,count_of_hg19_0based,count_of_hg20_0based,count_of_hg18_1based,count_of_hg19_1based,count_of_hg20_1based:	0 , 0 , 0 , 0 , 0 , 0
 which_build_gwas,which_build_ref:	unknown , hg19_1
-gwas_count_known,gwas_count_unknown:	1'013 , 1
+gwas_count_known,gwas_count_unknown:	160 , 854
 Delete the SNPs with unknown position ...
-gwas->number_of_snps():1'013
+gwas->number_of_snps():160
 options:: opt_window_width,options:: opt_flanking_width:	250'000 , 250'000
 N_reference:503
 

--- a/tests/sub1KG-tiny/EUR.via.filter.all22..tag.snps/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22..tag.snps/command
@@ -8,5 +8,5 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
        --tag.snps   "${COMMANDDIR}"/_--tag.snps                                     \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"

--- a/tests/sub1KG-tiny/EUR.via.filter.all22.reimputeall/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22.reimputeall/command
@@ -8,7 +8,7 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
     --reimpute.tags                                                                 \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/sub1KG-tiny/EUR.via.filter.all22/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.all22/command
@@ -7,7 +7,7 @@
     --wind 250000                                                                   \
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
-    --_debug_build_chr 20 --_debug_build_chr 21 --_debug_build_chr 22               \
+    --impute.range 20-22                                                            \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/sub1KG-tiny/EUR.via.filter.chr4.5/command
+++ b/tests/sub1KG-tiny/EUR.via.filter.chr4.5/command
@@ -8,7 +8,6 @@
     --flan 250000                                                                   \
     --lambda 0.01                                                                   \
     --tag.range chr4-chr5                                                          \
-    --_debug_build_chr 4 --_debug_build_chr 5                                       \
     >     "$OUTPUT"
     #--ref "$REF"/tbi/small.vcf.sample.vcf.gz                                        \
     #--ref "$REF"/link.to.1kg.data/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz \

--- a/tests/swapping/swap.just.the.allele.headers/command
+++ b/tests/swapping/swap.just.the.allele.headers/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                  \
     --lambda 0.01                                                               \
     --impute.range chr1-chr3                                                    \
-    --_debug_build_chr 1 --_debug_build_chr 2 --_debug_build_chr 3              \
     > "$OUTPUT"

--- a/tests/swapping/swap.some.alleles.and.their.zs/command
+++ b/tests/swapping/swap.some.alleles.and.their.zs/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                  \
     --lambda 0.01                                                               \
     --impute.range chr1-chr3                                                    \
-    --_debug_build_chr 1 --_debug_build_chr 2 --_debug_build_chr 3              \
     > "$OUTPUT"

--- a/tests/swapping/swap.some.alleles/command
+++ b/tests/swapping/swap.some.alleles/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                  \
     --lambda 0.01                                                               \
     --impute.range chr1-chr3                                                    \
-    --_debug_build_chr 1 --_debug_build_chr 2 --_debug_build_chr 3              \
     > "$OUTPUT"

--- a/tests/tags.maf/tags.maf.0.01/command
+++ b/tests/tags.maf/tags.maf.0.01/command
@@ -6,5 +6,4 @@
     --lambda 0.01                                                                           \
     --tag.maf  0.0100                                                                      \
     --impute.range  chr1-chr2                                                         \
-    --_debug_build_chr 1 --_debug_build_chr 2                                       \
     > "$OUTPUT"

--- a/tests/tags.range/chr1_1000000-chr1_2000000/command
+++ b/tests/tags.range/chr1_1000000-chr1_2000000/command
@@ -6,5 +6,4 @@
     --lambda 0.01                                                                   \
     --tags.used.output "${COMMANDDIR}"/tag.data.used.here.tsv                       \
     --tag.range  chr1:18016491-chr1:18490574   \
-    --_debug_build_chr 1                                                            \
     > "$OUTPUT"

--- a/tests/tags.range/chr2-3/command
+++ b/tests/tags.range/chr2-3/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.01                                                                   \
     --tag.range  chr2-3                                                             \
-    --_debug_build_chr 2 --_debug_build_chr 3                                       \
     > "$OUTPUT"

--- a/tests/tags.range/chr2/command
+++ b/tests/tags.range/chr2/command
@@ -5,5 +5,4 @@
     --out "${OUT_IMPUTATIONS}"                                                      \
     --lambda 0.01                                                                   \
     --tag.range  chr2                                                               \
-    --_debug_build_chr 2                                                            \
     > "$OUTPUT"

--- a/tests/test.whatever/command
+++ b/tests/test.whatever/command
@@ -5,5 +5,4 @@
     --out ${OUT_IMPUTATIONS}                                                    \
     --lambda 0.01                                                               \
     --impute.range chr8-chr9                                                    \
-    --_debug_build_chr 8 --_debug_build_chr 9                                       \
     > "$OUTPUT"

--- a/tests/test.wood/command
+++ b/tests/test.wood/command
@@ -8,5 +8,5 @@
     --lambda 0.08917559                                                             \
     --tag.snp <(echo rs136382 rs136383 rs136389 | tr ' ' '\n')                     \
     --impute.snp <(echo rs5753220 rs5753231 rs5753236 rs5753259 rs5753260 rs5753263 rs5753268 rs5753271 rs5753272 rs5753281 rs5753284 rs5753285 rs5753290 rs5753298 | tr ' ' '\n')                     \
-    --_debug_build_chr 22                                                           \
+    --impute.range 22                                                               \
     >     "$OUTPUT"


### PR DESCRIPTION
As a follow up to #84, and basically replacing it(!), this PR looks at the `--impute.range` and `--tag.range` options and loads only the chromosomes that are included in those ranges

As a result, the `--_debug_build_chr` is no longer really needed and it is not included in any tests any more