### PR TITLE
Error messages with line numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+gmon.txt
+time.and.memory.txt
 reference_panels/
 bin/
 src/libStatGen/general/obj/BaseAsciiMap.o

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -394,11 +394,14 @@ GwasFileHandle_NONCONST      read_in_a_gwas_file_simple(std:: string file_name) 
     p->m_delimiter            = hd.m_delimiter;
     p->m_header_details       = hd;
 
+    int line_number = 1;
+
     while(1) {
         GwasLineSummary gls;
         getline(f, current_line);
+	++line_number;
         if(!f) {
-            f.eof() || DIE("Error before reaching eof() in this file");
+            f.eof() || DIE("Error before reaching eof() in this file. Line number: " << line_number);
             break;
         }
         auto all_split_up = tokenize(current_line, hd.m_delimiter);

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -456,7 +456,7 @@ GwasFileHandle_NONCONST      read_in_a_gwas_file_simple(std:: string file_name) 
 
             p->m_each_SNP_and_its_z.push_back(gls);
         } catch (std:: invalid_argument &e) {
-            WARNING( "Ignoring this line, problem with the chromosome and/or position ["
+            WARNING( "Ignoring line [" << file_name << ":" << line_number << "], problem with the chromosome and/or position ["
                     << "SNPname:" << LOOKUP(hd, SNPname   , all_split_up)
                     //<< " chr:" << LOOKUP(hd, chromosome, all_split_up)
                     //<< " pos:" << LOOKUP(hd, position  , all_split_up)

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -124,6 +124,7 @@ GwasFileHandle_NONCONST      read_in_a_gwas_file_simple(std:: string file_name);
 char   decide_delimiter( string      const & header_line );
 
 struct GwasLineSummary {
+    int                      m_gwas_line_number;
     string                   m_SNPname;
     chrpos                   m_chrpos;
     string                   m_allele_alt;
@@ -300,6 +301,9 @@ struct SimpleGwasFile : public file_reading:: Effects_I
     virtual int         number_of_snps() const {
         return m_each_SNP_and_its_z.size();
     }
+    virtual int         get_line_number    (int i)     const {
+        return get_gls(i).m_gwas_line_number;
+    }
     virtual std::string get_SNPname        (int i)     const {
         auto const & ols = get_gls(i);
         return ols.m_SNPname;
@@ -400,6 +404,7 @@ GwasFileHandle_NONCONST      read_in_a_gwas_file_simple(std:: string file_name) 
         GwasLineSummary gls;
         getline(f, current_line);
 	++line_number;
+	gls.m_gwas_line_number = line_number;
         if(!f) {
             f.eof() || DIE("Error before reaching eof() in this file. Line number: " << line_number);
             break;

--- a/src/file.reading.cc
+++ b/src/file.reading.cc
@@ -416,7 +416,7 @@ GwasFileHandle_NONCONST      read_in_a_gwas_file_simple(std:: string file_name) 
                 else { // no 'z' field. Must infer it from 'p' and 'beta', with 'beta' used only for 'direction'
                     auto beta   = utils:: lexical_cast<double> (LOOKUP( hd, effect_beta, all_split_up));
                     auto p      = utils:: lexical_cast<double> (LOOKUP( hd, effect_p   , all_split_up));
-                    (p >= 0 && p <= 1)    || DIE("Your p should be between 0 and 1 [" << p << "]");
+                    (p >= 0 && p <= 1)    || DIE("Your p should be between 0 and 1 [p=" << p << "]. Line number: " << line_number);
                     auto z_undir = gsl_cdf_gaussian_Pinv( p / 2.0 ,1);
                     assert(z_undir <= 0.0);
                     double z;

--- a/src/file.reading.hh
+++ b/src/file.reading.hh
@@ -76,6 +76,7 @@ std:: ostream& operator<<(std:: ostream &o, chrpos const &c) {
 
 struct AnyFile_I {
     virtual int         number_of_snps     ()        const = 0;
+    virtual int         get_line_number    (int)     const = 0;
     virtual std::string get_SNPname        (int)     const = 0;
     virtual chrpos      get_chrpos         (int)     const = 0;
     virtual std::string get_allele_ref     (int)     const = 0;

--- a/src/module-bits.and.pieces/utils.hh
+++ b/src/module-bits.and.pieces/utils.hh
@@ -14,6 +14,8 @@
 
 #include "ASSERT.hh"
 
+#define EASYSTRING(...) [&]{std::ostringstream oss1234abcd; oss1234abcd << __VA_ARGS__; return oss1234abcd.str();}()
+
 namespace utils {
 namespace impl {
     template<typename ...T>
@@ -277,7 +279,7 @@ int lexical_cast<int>(std:: string const & s) {
         return d;
     }
     else
-        throw std:: invalid_argument{"can't parse this int"};
+        throw std:: invalid_argument{EASYSTRING("can't parse this int [" << s << "]")};
 }
 template<>
 inline

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -885,28 +885,33 @@ int main(int argc, char **argv) {
                 gwas->set_chrpos(i, chrpos{-1,-1});
             }
             for(int i = 0; i<gwas->number_of_snps(); ++i ) {
-                auto   gwas_rs      =   gwas->get_SNPname(i);
-                if(gwas_rs.substr(0,2) == "rs") {
-                    int gwas_rs_int = utils:: lexical_cast<int>(gwas_rs.substr(2));
-                    //PP(gwas_rs, gwas_rs_int);
-                    if(1==database_of_builds_rs_to_offset.count(gwas_rs_int)) {
-                        auto offset_into_big_db = database_of_builds_rs_to_offset[gwas_rs_int];
-                        assert(database_of_builds.at(offset_into_big_db).rs == gwas_rs_int);
-                        chrpos new_chrpos = get_one_build(database_of_builds.at(offset_into_big_db), which_build_ref);
-                        if (new_chrpos.pos == -1) {
-                            // we can't do anything here, as we don't know its position.
-                            // This is a SNP which is known in at least one build (hence
-                            // it's in the database), but it's not known in the desired
-                            // build
-                        } else {
-                            assert(new_chrpos != (chrpos{-1,0}));
-                            gwas->set_chrpos(i, new_chrpos);
-                        }
-                    } else {
-                        // not in the database - should we delete it?
-                        // TODO: decide whether to delete or now
-                    }
-                }
+		try {
+		    auto   gwas_rs      =   gwas->get_SNPname(i);
+		    if(gwas_rs.substr(0,2) == "rs") {
+			int gwas_rs_int = utils:: lexical_cast<int>(gwas_rs.substr(2));
+			//PP(gwas_rs, gwas_rs_int);
+			if(1==database_of_builds_rs_to_offset.count(gwas_rs_int)) {
+			    auto offset_into_big_db = database_of_builds_rs_to_offset[gwas_rs_int];
+			    assert(database_of_builds.at(offset_into_big_db).rs == gwas_rs_int);
+			    chrpos new_chrpos = get_one_build(database_of_builds.at(offset_into_big_db), which_build_ref);
+			    if (new_chrpos.pos == -1) {
+				// we can't do anything here, as we don't know its position.
+				// This is a SNP which is known in at least one build (hence
+				// it's in the database), but it's not known in the desired
+				// build
+			    } else {
+				assert(new_chrpos != (chrpos{-1,0}));
+				gwas->set_chrpos(i, new_chrpos);
+			    }
+			} else {
+			    // not in the database - should we delete it?
+			    // TODO: decide whether to delete or now
+			}
+		    }
+		} catch (...) {
+		    std::cerr << "Error in the GWAS file, while reading line " << gwas->get_line_number(i) << ".\n";
+		    throw;
+		}
             }
             for(int i = 0; i<gwas->number_of_snps(); ++i ) { assert(gwas->get_chrpos(i) != (chrpos{-1,0}) ); }
             which_build_gwas = which_build_ref; // we've changed the gwas positions, so we here record that fact

--- a/tests/errors.and.logging/log/log.txt
+++ b/tests/errors.and.logging/log/log.txt
@@ -1,3 +1,3 @@
 file_name:/nonexistent/../..
 
-Exiting: src/file.reading.cc:380	Error: Can't find file [/nonexistent/../..]
+Exiting: src/file.reading.cc:384	Error: Can't find file [/nonexistent/../..]

--- a/tests/errors.and.logging/log/output.stderr
+++ b/tests/errors.and.logging/log/output.stderr
@@ -1,2 +1,2 @@
 
-Exiting: src/file.reading.cc:380	Error: Can't find file [/nonexistent/../..]
+Exiting: src/file.reading.cc:384	Error: Can't find file [/nonexistent/../..]


### PR DESCRIPTION
This adds a little bit of extra information when ssimp crashes if it was due to a parsing error - for example printing the line number of the GWAS file. Hopefully this information will help debugging, and helps users to identify which line is the problematic line