### PR TITLE
bugfix number effective tests

### DIFF
--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -1598,7 +1598,7 @@ void impute_all_the_regions(   string                                   filename
             // Compute the imputations
             auto c_Cinv_zs = mvn:: multiply_matrix_by_colvec_giving_colvec(c_lambda, solve_a_matrix (C_lambda, mvn:: make_VecCol(tag_zs_)));
 
-            int number_of_effective_tests_in_C_nolambda = compute_number_of_effective_tests_in_C_nolambda(C_lambda);
+            int number_of_effective_tests_in_C_nolambda = compute_number_of_effective_tests_in_C_nolambda(C_nolambda);
 
             // if necessary, do reimputation
             // TODO: what is the r2 for the reimputation? I'm being 'naive' for now


### PR DESCRIPTION
- Ninon + Zoltán found the bug that introduced lots of incorrect R2s
- now the `number_of_effective_tests_in_C_nolambda` is computed with the C matrix that is not adjusted for lambda. 