### PR TITLE
Three small changes

### DIFF
--- a/bin.stu
+++ b/bin.stu
@@ -1,7 +1,9 @@
 @all: @tags bin/ssimp;
 
     bin/ssimp
-:   $[LINKER=bin/o/LINKER]
+:
+    @report_the_compiler_version
+    $[LINKER=bin/o/LINKER]
     $[LD_FLAGS=bin/o/LD_FLAGS]
 
     bin/o/ssimp.o
@@ -119,6 +121,17 @@
 
     echo " -O3"
     echo " -Wall -Wextra -std=c++14"
+}
+
+@report_the_compiler_version
+:   $[CXX_WITH_FLAGS=bin/o/CXX_WITH_FLAGS]
+{
+    echo  ============
+    echo We have found the following C++ compiler on your system.
+    echo This will be used to compile 'ssimp':
+    echo
+    ${CXX_WITH_FLAGS} --version
+    echo  ============
 }
 
 >       bin/o/LINKER

--- a/src/module-bits.and.pieces/utils.hh
+++ b/src/module-bits.and.pieces/utils.hh
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <vector>
 #include <cmath>
+#include <time.h>
 #include <tuple> // for tuple::get
 #include <utility> // for tuple::get
 #include <vector>

--- a/src/ssimp.cc
+++ b/src/ssimp.cc
@@ -1769,7 +1769,7 @@ make_C_tag_tag_matrix( vector<vector<TYPE_OF_ONE_REF_CELL> const *>      const &
                 c_kl =-1.0;
             }
 	    
-	    if (isnan(c_kl)) { //in case of missing correlation values caused by monomorphic SNPs
+	    if (std::isnan(c_kl)) { //in case of missing correlation values caused by monomorphic SNPs
 	    	if (k==l) {
 			c_kl=1.0;
 		}
@@ -1849,7 +1849,7 @@ mvn:: Matrix make_c_unkn_tags_matrix
                     c_ku = -1.0;
                 }
 		
-		if (isnan(c_ku)) { //in case of missing correlation values caused by monomorphic SNPs
+		if (std::isnan(c_ku)) { //in case of missing correlation values caused by monomorphic SNPs
 			c_ku=0.0;
 	    	} 
 

--- a/stu/timestamp.hh
+++ b/stu/timestamp.hh
@@ -1,6 +1,8 @@
 #ifndef TIMESTAMP_HH
 #define TIMESTAMP_HH
 
+#include <time.h>
+
 /* 
  * Wrapper around time_t or struct timespec.  There are two variants:
  *   - default:  1-second precision.


### PR DESCRIPTION
 1. As suggested in #114, this adds two includes for time.h that Peter needed on his machine
 2. While I (Aaron) was compiling this on my oldish laptop (g++ 7.5 from 2017), I found there was a problem with including `isnan`. So I just had to change two instances of `isnan` to `std::isnan`.
 3. I added a bit of code to the compilation process such that it prints the compiler that is being used. I have two C++ compilers on my machine and I wasn't sure which one it was using. It prints something like this:

```
$ make
....
   Building 'bin/ssimp'

stu/stu bin/ssimp
Building @report_the_compiler_version
============
We have found the following C++ compiler on your system.
This will be used to compile ssimp:

g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

============
...
```